### PR TITLE
Fix SwooshWrapper | Update on discord-colors/Custom.css

### DIFF
--- a/data/discord-colors/Custom.css
+++ b/data/discord-colors/Custom.css
@@ -9,8 +9,14 @@ a:hover {
 
 /*  Apply margin to server scroller */
 [class*="SidebarBase"]:first-child > [class^="Base-sc"] {
-  margin: 10px;
+    margin-bottom: 10px;
+    margin-left: 10px;
+    margin-right: 10px;
 }
+
+[data-test-id^="virtuoso-item-list"]{
+	margin-top: 10px !important;
+} 
 
 [class*="SidebarBase"]
   > [class^="Base-sc"]


### PR DESCRIPTION
Previous:
![](https://user-images.githubusercontent.com/21064622/230416917-20aca379-99da-45c8-ad49-febf599d9760.png)

Now:
![](https://user-images.githubusercontent.com/21064622/230429699-21d73eca-381d-42ea-9f7d-d48da06e9d90.png)

## Please make sure to check the following tasks before opening and submitting a PR)


* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects
