### PR TITLE
update: Nucleon and Glass styling for invite links

### DIFF
--- a/data/glass/Custom.css
+++ b/data/glass/Custom.css
@@ -1,7 +1,7 @@
-._11Ivv {
+._11Ivv, ._invite_hx3lg_1 {
     background: url("https://autumn.revolt.chat/attachments/FQkCgdyHs4z9OXbdGfbF396uhPahc3seYRFMdEMZqp/axo-theme-bg.jpg");
-    background-repeat: no-repeat;
-    background-size: cover;
+    background-repeat: no-repeat !important;
+    background-size: cover !important;
 }
 
 .PreloaderBase-sc-1xcl5li-0.ddQdoB {
@@ -23,6 +23,17 @@
     margin-left: 1rem;
     border-radius: 0 0 6px 6px;
     margin-top: -1rem;
+}
+
+._details_hx3lg_31 {
+    background: #11111192;
+    backdrop-filter: blur(3px);
+    width: 25rem;
+    max-width: calc(100% - 2rem);
+}
+
+._details_hx3lg_31 h1 {
+    font-size: 1.4rem;
 }
 
 .AutoComplete__Base-sc-dtvq9c-0.hkukmG > div {

--- a/data/nucleon/Custom.css
+++ b/data/nucleon/Custom.css
@@ -1,7 +1,7 @@
-._11Ivv {
+._11Ivv, ._invite_hx3lg_1 {
     background: url("https://autumn.revolt.chat/attachments/FQkCgdyHs4z9OXbdGfbF396uhPahc3seYRFMdEMZqp/axo-theme-bg.jpg");
-    background-repeat: no-repeat;
-    background-size: cover;
+    background-repeat: no-repeat !important;
+    background-size: cover !important;
 }
 
 .PreloaderBase-sc-1xcl5li-0.ddQdoB {
@@ -23,6 +23,17 @@
     margin-left: 1rem;
     border-radius: 0 0 6px 6px;
     margin-top: -1rem;
+}
+
+._details_hx3lg_31 {
+    background: #11111192;
+    backdrop-filter: blur(3px);
+    width: 25rem;
+    max-width: calc(100% - 2rem);
+}
+
+._details_hx3lg_31 h1 {
+    font-size: 1.4rem;
 }
 
 .AutoComplete__Base-sc-dtvq9c-0.hkukmG > div {


### PR DESCRIPTION
* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects

Before:
<img width="960" alt="image" src="https://github.com/revoltchat/themes/assets/78349410/a3a09952-9ef0-423b-a0e8-5d174ee79e38">

Now:
<img width="960" alt="image" src="https://github.com/revoltchat/themes/assets/78349410/27498770-1406-454a-810e-e0bdb9cc4c42">

`❓` Does it interfere if the user sets a banner themselves? No.

<img width="960" alt="image" src="https://github.com/revoltchat/themes/assets/78349410/fea5a14c-d365-40ec-b713-f4884ff2686f">

