### PR TITLE
Update Social Classic theme

### DIFF
--- a/data/social-classic/Custom.css
+++ b/data/social-classic/Custom.css
@@ -1,6 +1,9 @@
 /* Constants */
 
 :root{
+  /* --background: #F6F6F6;
+  --foreground: #101010; */
+  --primary-header: #F1F1F1;
   --serverbar-background: #303440;
   --serverbar-foreground: #F7F7F7;
   --serverbar-border: #1C202B;
@@ -286,6 +289,10 @@ div[class^="Home__Overlay-sc"] > .content h3 > img {
   padding: 4px 6px;
   border-radius: 0px;
   margin: -5px 4px -6px -4px;
+}
+
+.cYBcvy {
+  --emoji-size: 3.428em; /* 48px */
 }
 
 .fDfxAc { /* Reactions */

--- a/data/social-classic/Preset.toml
+++ b/data/social-classic/Preset.toml
@@ -3,7 +3,7 @@ name = "Social Classic"
 creator = "DragShot"
 description = "A mixture of light, dark and a primary color of your preference, inspired by social websites from the 2010s."
 tags = ["social", "classic", "light", "2010"]
-version = "v1.0.0"
+version = "v1.0.1"
 
 [variables]
 light = true
@@ -12,8 +12,8 @@ background = "#F6F6F6"
 foreground = "#101010"
 
 block = "#414141"
-message-box = "#F1F1F1"
-mention = "rgba(251, 255, 0, 0.40)"
+message-box = "#E2E6F0"
+mention = "#FFF5CE"
 
 success = "#65E572"
 warning = "#FAA352"
@@ -26,16 +26,16 @@ track = "transparent"
 
 [variables.primary]
 background = "#FFFFFF"
-header = "#F1F1F1"
+header = "#3B5998"
 
 [variables.secondary]
 background = "#F1F1F1"
-foreground = "#888888"
+foreground = "#1f1f1f"
 header = "#F1F1F1"
 
 [variables.tertiary]
 background = "#4D4D4D"
-foreground = "#646464"
+foreground = "#3A3A3A"
 
 [variables.status]
 online = "#3ABF7E"


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

* [X] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [X] I have tested my changes locally and they are working as intended
* [X] These changes do not have any notable side effects on other Revolt projects

# Social Classic Theme Update

This patch increases the contrast of secondary text on the theme to what was originally intended. It also sets a couple of defaults in order to improve the accuracy of the preview a bit. The only element missing from the preview would be the dark sidebar, but my attempts to change that only messed with the Discover page, so in the end this is the best I could do with the current state of Revite.

![Preview Update](https://autumn.revolt.chat/attachments/hlU_Q9WL3I8Qwq8S-mXz8Iba0m7UPhx04MCNf_7Hjb/imagen.png)