### PR TITLE
feat(catppuccin): sync themes with catppuccin/revolt

### DIFF
--- a/data/catppuccin-frappe/Custom.css
+++ b/data/catppuccin-frappe/Custom.css
@@ -1,3 +1,0 @@
-[data-type="mention"] {
-  border-radius: 4px !important;
-}

--- a/data/catppuccin-frappe/Preset.toml
+++ b/data/catppuccin-frappe/Preset.toml
@@ -3,16 +3,16 @@ name = "Catppuccin Frappé"
 creator = "Catppuccin Org"
 description = "Soothing pastel theme for Revolt."
 tags = ["pastel", "soothing", "dark"]
-version = "1.0.0"
+version = "2.0.0"
 
 [variables]
 light = false
-accent = "#f2d5cf"
+accent = "#ca9ee6"
 background = "#303446"
-foreground = "#babbf1"
+foreground = "#c6d0f5"
 block = "#232634"
 message-box = "#232634"
-mention = "rgba(30, 29, 47, .1)"
+mention = "rgba(48, 52, 70, 0.10)"
 success = "#a6d189"
 warning = "#ef9f76"
 tooltip = "#000000"
@@ -38,7 +38,8 @@ foreground = "#626880"
 
 [variables.status]
 online = "#a6d189"
-away = "#eebebe"
-busy = "#ea999c"
+away = "#e5c890"
+focus = "#8caaee"
+busy = "#e78284"
 streaming = "#ca9ee6"
 invisible = "#626880"

--- a/data/catppuccin-latte/Custom.css
+++ b/data/catppuccin-latte/Custom.css
@@ -1,3 +1,0 @@
-[data-type="mention"] {
-  border-radius: 4px !important;
-}

--- a/data/catppuccin-latte/Preset.toml
+++ b/data/catppuccin-latte/Preset.toml
@@ -3,16 +3,16 @@ name = "Catppuccin Latte"
 creator = "Catppuccin Org"
 description = "Soothing pastel theme for Revolt."
 tags = ["pastel", "soothing", "light"]
-version = "1.0.0"
+version = "2.0.0"
 
 [variables]
 light = true
-accent = "#dc8a78"
+accent = "#8839ef"
 background = "#eff1f5"
-foreground = "#7287fd"
+foreground = "#4c4f69"
 block = "#dce0e8"
 message-box = "#dce0e8"
-mention = "rgba(30, 29, 47, .1)"
+mention = "rgba(239, 241, 245, 0.10)"
 success = "#40a02b"
 warning = "#fe640b"
 tooltip = "#000000"
@@ -38,7 +38,8 @@ foreground = "#acb0be"
 
 [variables.status]
 online = "#40a02b"
-away = "#dd7878"
-busy = "#e64553"
+away = "#df8e1d"
+focus = "#1e66f5"
+busy = "#d20f39"
 streaming = "#8839ef"
 invisible = "#acb0be"

--- a/data/catppuccin-macchiato/Custom.css
+++ b/data/catppuccin-macchiato/Custom.css
@@ -1,3 +1,0 @@
-[data-type="mention"] {
-  border-radius: 4px !important;
-}

--- a/data/catppuccin-macchiato/Preset.toml
+++ b/data/catppuccin-macchiato/Preset.toml
@@ -3,16 +3,16 @@ name = "Catppuccin Macchiato"
 creator = "Catppuccin Org"
 description = "Soothing pastel theme for Revolt."
 tags = ["pastel", "soothing", "dark"]
-version = "1.0.0"
+version = "2.0.0"
 
 [variables]
 light = false
-accent = "#f4dbd6"
+accent = "#c6a0f6"
 background = "#24273a"
-foreground = "#b7bdf8"
+foreground = "#cad3f5"
 block = "#181926"
 message-box = "#181926"
-mention = "rgba(30, 29, 47, .1)"
+mention = "rgba(36, 39, 58, 0.10)"
 success = "#a6da95"
 warning = "#f5a97f"
 tooltip = "#000000"
@@ -38,7 +38,8 @@ foreground = "#5b6078"
 
 [variables.status]
 online = "#a6da95"
-away = "#f0c6c6"
-busy = "#ee99a0"
+away = "#eed49f"
+focus = "#8aadf4"
+busy = "#ed8796"
 streaming = "#c6a0f6"
 invisible = "#5b6078"

--- a/data/catppuccin-mocha/Custom.css
+++ b/data/catppuccin-mocha/Custom.css
@@ -1,3 +1,0 @@
-[data-type="mention"] {
-  border-radius: 4px !important;
-}

--- a/data/catppuccin-mocha/Preset.toml
+++ b/data/catppuccin-mocha/Preset.toml
@@ -3,16 +3,16 @@ name = "Catppuccin Mocha"
 creator = "Catppuccin Org"
 description = "Soothing pastel theme for Revolt."
 tags = ["pastel", "soothing", "dark"]
-version = "1.0.0"
+version = "2.0.0"
 
 [variables]
 light = false
-accent = "#f5e0dc"
+accent = "#cba6f7"
 background = "#1e1e2e"
-foreground = "#b4befe"
+foreground = "#cdd6f4"
 block = "#11111b"
 message-box = "#11111b"
-mention = "rgba(30, 29, 47, .1)"
+mention = "rgba(30, 30, 46, 0.10)"
 success = "#a6e3a1"
 warning = "#fab387"
 tooltip = "#000000"
@@ -38,7 +38,8 @@ foreground = "#585b70"
 
 [variables.status]
 online = "#a6e3a1"
-away = "#f2cdcd"
-busy = "#eba0ac"
+away = "#f9e2af"
+focus = "#89b4fa"
+busy = "#f38ba8"
 streaming = "#cba6f7"
 invisible = "#585b70"


### PR DESCRIPTION
## Description

Hey :wave:,

This PR brings in changes brought about over at [catppuccin/revolt](https://github.com/catppuccin/revolt) via https://github.com/catppuccin/revolt/pull/5:

- Custom CSS is removed
- Accent is defaulted to `mauve`
- Foreground is changed to `text` instead of `lavender`
- Status Focus symbol is styled as `blue`

I've bumped the version to `2.0.0` since the primary `accent` colour is changing. Let me know if I need to do anything else, thanks!

## Please make sure to check the following tasks before opening and submitting a PR

- [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [x] I have tested my changes locally and they are working as intended
